### PR TITLE
Add a subclass that uses a bucket per domain

### DIFF
--- a/src/httpx_limiter/async_rate_limited_transport.py
+++ b/src/httpx_limiter/async_rate_limited_transport.py
@@ -79,3 +79,11 @@ class AsyncRateLimitedTransport(httpx.AsyncBaseTransport):
         """Handle an asynchronous request with rate limiting."""
         async with self._limiter:
             return await self._transport.handle_async_request(request)
+
+class AsyncDomainRateLimitedTransport(AsyncRateLimitedTransport):
+    async def handle_async_request(
+        self,
+        request: httpx.Request,
+    ) -> httpx.Response:
+        async with self._limiter(bucket=".".join(request.url.host.split(".")[-2:])):
+            return await self._transport.handle_async_request(request)


### PR DESCRIPTION
Splits `Request().url.host` on period, and uses the last two parts as the bucket name for the limiter. This lets you have identical limits for all domains, but independant of each other, so and example.org request doesn't have to wait for capacity because of previous example.com requests

- [ ] fix #(issue number)
- [ ] description of feature/fix
- [ ] tests added/passed
- [ ] add an entry to the [changelog](../CHANGELOG.md)
