### PR TITLE
Add fallback type annotation

### DIFF
--- a/src/httpx_limiter/types.py
+++ b/src/httpx_limiter/types.py
@@ -17,9 +17,19 @@
 
 import ssl
 import typing
-from typing import TypedDict
+from typing import TypeAlias, TypedDict
 
 import httpx
+
+
+try:
+    socket_option_type: TypeAlias = httpx._transports.default.SOCKET_OPTION
+except AttributeError:
+    socket_option_type: TypeAlias = typing.Union[  # type: ignore
+        typing.Tuple[int, int, int],
+        typing.Tuple[int, int, typing.Union[bytes, bytearray]],
+        typing.Tuple[int, int, None, int],
+    ]  # Fallback for Pyodide HTTPX. See: https://github.com/Midnighter/httpx-limiter/pull/10#issuecomment-3241566927
 
 
 class HTTPXAsyncHTTPTransportKeywordArguments(TypedDict, total=False):
@@ -35,4 +45,4 @@ class HTTPXAsyncHTTPTransportKeywordArguments(TypedDict, total=False):
     uds: str | None
     local_address: str | None
     retries: int
-    socket_options: typing.Iterable[httpx._transports.default.SOCKET_OPTION] | None
+    socket_options: typing.Iterable[socket_option_type] | None


### PR DESCRIPTION
- [x] fix related to #9 
- [x] description of feature/fix
- [x] tests added/passed
- [ ] add an entry to the [changelog](../CHANGELOG.md)

## Description

This PR fixes type annotation `httpx._transports.default.SOCKET_OPTION` throwing `AttributeError` in a Pyodide environment. See: https://github.com/Midnighter/httpx-limiter/pull/10#issuecomment-3241566927