### PR TITLE
Fix failed OTel exports

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -33,19 +33,3 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       version: latest
-
-  otel-trace:
-    if: always()
-    name: Export trace to Honeycomb
-    needs: [prerequisites, pyodide, documentation]
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Export workflow run to Honeycomb
-        uses: dash0hq/otel-cicd-action@895874bfae14f840e3032f1a14c3f2b45c93f4af # v4.1.1
-        with:
-          otlpEndpoint: ${{ vars.HONEYCOMB_OTLP_ENDPOINT }}
-          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,22 +72,3 @@ jobs:
       - name: Build documentation without alias
         if: inputs.alias == ''
         run: hatch run docs:deploy -- --push "${{ inputs.version }}"
-
-  otel-trace:
-    # Only trace when this workflow is the entry point; when called via
-    # `workflow_call` from another workflow, that workflow's own tracer
-    # job covers these jobs already.
-    if: always() && github.event_name == 'workflow_dispatch'
-    name: Export trace to Honeycomb
-    needs: [documentation]
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Export workflow run to Honeycomb
-        uses: dash0hq/otel-cicd-action@895874bfae14f840e3032f1a14c3f2b45c93f4af # v4.1.1
-        with:
-          otlpEndpoint: ${{ vars.HONEYCOMB_OTLP_ENDPOINT }}
-          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/export-otel.yml
+++ b/.github/workflows/export-otel.yml
@@ -1,0 +1,29 @@
+name: Export OTel
+
+on:
+  workflow_run:
+    workflows:
+      - "CI"
+      - "CD"
+      - "Cron Test"
+      - "Auto-Merge Dependabot PR"
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  otel-trace:
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+      checks: read
+    steps:
+      - name: Export workflow run's traces
+        uses: dash0hq/otel-cicd-action@895874bfae14f840e3032f1a14c3f2b45c93f4af # v4.1.1
+        with:
+          otlpEndpoint: ${{ vars.HONEYCOMB_OTLP_ENDPOINT }}
+          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/export-otel.yml
+++ b/.github/workflows/export-otel.yml
@@ -13,6 +13,7 @@ permissions: {}
 
 jobs:
   otel-trace:
+    if: ${{ github.event.workflow_run.head_repository.full_name == github.repository }}
     runs-on: ubuntu-slim
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,19 +38,3 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       version: latest
-
-  otel-trace:
-    if: always()
-    name: Export trace to Honeycomb
-    needs: [prerequisites, pyodide, documentation]
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Export workflow run to Honeycomb
-        uses: dash0hq/otel-cicd-action@895874bfae14f840e3032f1a14c3f2b45c93f4af # v4.1.1
-        with:
-          otlpEndpoint: ${{ vars.HONEYCOMB_OTLP_ENDPOINT }}
-          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -58,22 +58,3 @@ jobs:
       browser: firefox
       runner: selenium
       pyodide-version: 0.27.2
-
-  otel-trace:
-    # Only trace when this workflow is the entry point; when called via
-    # `workflow_call` from another workflow, that workflow's own tracer
-    # job covers these jobs already.
-    if: always() && github.event_name == 'workflow_dispatch'
-    name: Export trace to Honeycomb
-    needs: [build, test]
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Export workflow run to Honeycomb
-        uses: dash0hq/otel-cicd-action@895874bfae14f840e3032f1a14c3f2b45c93f4af # v4.1.1
-        with:
-          otlpEndpoint: ${{ vars.HONEYCOMB_OTLP_ENDPOINT }}
-          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,19 +75,3 @@ jobs:
     with:
       version: ${{ github.ref_name }}
       alias: stable
-
-  otel-trace:
-    if: always()
-    name: Export trace to Honeycomb
-    needs: [prerequisites, pyodide, release, documentation]
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Export workflow run to Honeycomb
-        uses: dash0hq/otel-cicd-action@895874bfae14f840e3032f1a14c3f2b45c93f4af # v4.1.1
-        with:
-          otlpEndpoint: ${{ vars.HONEYCOMB_OTLP_ENDPOINT }}
-          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,22 +161,3 @@ jobs:
           files: coverage.xml
           flags: doc-tests
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  otel-trace:
-    # Only trace when this workflow is the entry point; when called via
-    # `workflow_call` from another workflow, that workflow's own tracer
-    # job covers these jobs already.
-    if: always() && github.event_name == 'workflow_dispatch'
-    name: Export trace to Honeycomb
-    needs: [lint, unit-tests, acceptance-tests, documentation-tests]
-    runs-on: ubuntu-slim
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Export workflow run to Honeycomb
-        uses: dash0hq/otel-cicd-action@895874bfae14f840e3032f1a14c3f2b45c93f4af # v4.1.1
-        with:
-          otlpEndpoint: ${{ vars.HONEYCOMB_OTLP_ENDPOINT }}
-          otlpHeaders: ${{ secrets.HONEYCOMB_OTLP_HEADERS }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since dependabot has no access to repo secrets (it is treated like a fork), the export step kept failing.